### PR TITLE
Add seeds

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,3 +9,12 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+#
+
+unless Punkte.Repo.exists?("users") do
+  Punkte.Repo.query!("""
+  INSERT INTO users (id, points, inserted_at, updated_at)
+  SELECT gen_random_uuid(), 0, LOCALTIMESTAMP, LOCALTIMESTAMP FROM generate_series(1, 1000000)
+  """)
+end
+


### PR DESCRIPTION
This PR creates seeds for the users' table as following 

```
mix ecto.setup will create a Users table with 4 columns, id, points and the usual 2 timestamps.

id is autogenerated so no worries
points an integer that accepts any number between 0 and 100
timestamps autogenerated by ecto
This should generate 1,000,000 user seeds, each with 0 points.
```

![Screenshot 2023-05-23 at 19 28 03](https://github.com/GabrielMalakias/Punkte/assets/5194287/f2666a3b-8947-4321-ba80-5a452be92b2f)
