### PR TITLE
Change back to id and create db constraints

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,6 @@ import Config
 
 config :punkte,
   ecto_repos: [Punkte.Repo],
-  generators: [binary_id: true],
   workers: [],
   points_interval: 0..100,
   interval: :timer.minutes(1)

--- a/lib/punkte/user.ex
+++ b/lib/punkte/user.ex
@@ -2,8 +2,6 @@ defmodule Punkte.User do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "users" do
     field :points, :integer
 

--- a/priv/repo/migrations/20230523171555_create_users.exs
+++ b/priv/repo/migrations/20230523171555_create_users.exs
@@ -2,11 +2,14 @@ defmodule Punkte.Repo.Migrations.CreateUsers do
   use Ecto.Migration
 
   def change do
-    create table(:users, primary_key: false) do
-      add :id, :binary_id, primary_key: true
+    create table(:users) do
       add :points, :integer
 
       timestamps()
     end
+
+    create constraint(:users, :points_must_be_in_range, check: "points >= 0 AND points <= 100")
+
+    execute("ALTER TABLE users SET (fillfactor = 70)")
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -13,8 +13,8 @@
 
 unless Punkte.Repo.exists?("users") do
   Punkte.Repo.query!("""
-  INSERT INTO users (id, points, inserted_at, updated_at)
-  SELECT gen_random_uuid(), 0, LOCALTIMESTAMP, LOCALTIMESTAMP FROM generate_series(1, 1000000)
+  INSERT INTO users (points, inserted_at, updated_at)
+  SELECT 0, LOCALTIMESTAMP, LOCALTIMESTAMP FROM generate_series(1, 1000000)
   """)
 end
 


### PR DESCRIPTION
The README.md defines the JSON that should be returned as follows:

```
{
  'users': [{id: 1, points: 30}, {id: 72, points: 30}],
  'timestamp': `2020-07-30 17:09:33`
}
```

previously it was binary_id which made the id a UUID.

It changes the fill factor to 70% to increase the number of HOT updates:
https://www.cybertec-postgresql.com/en/hot-updates-in-postgresql-for-better-performance/

As the instructions also define that the number of points should be between [0 - 100] inclusive, this PR also adds a constraint for that.
 